### PR TITLE
[feat] 즐겨찾기 목록 조회 기능 구현

### DIFF
--- a/src/main/java/sopt/twosome/controller/FavoriteController.java
+++ b/src/main/java/sopt/twosome/controller/FavoriteController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sopt.twosome.dto.common.SuccessResponse;
 import sopt.twosome.dto.request.FavoriteCreateRequest;
+import sopt.twosome.dto.response.FavoriteListResponse;
 import sopt.twosome.exception.SuccessCode;
 
 import sopt.twosome.service.Favorite.FavoriteService;
@@ -36,5 +37,14 @@ public class FavoriteController {
     ){
         favoriteService.removeFavorites(memberId, favoriteIds, all);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_FAVORITES));
+    }
+
+    //즐겨찾기 목록 조회
+    @GetMapping("/v1/likes")
+    public ResponseEntity<SuccessResponse<FavoriteListResponse>> getFavorites(
+            @RequestHeader("Authorization") long memberId
+    ) {
+        FavoriteListResponse favoriteListResponse = favoriteService.getListFavorites(memberId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.GET_LIKES_MENU_LIST, favoriteListResponse ));
     }
 }

--- a/src/main/java/sopt/twosome/dto/response/FavoriteListResponse.java
+++ b/src/main/java/sopt/twosome/dto/response/FavoriteListResponse.java
@@ -1,0 +1,33 @@
+package sopt.twosome.dto.response;
+
+import sopt.twosome.enums.CoffeeBean;
+import sopt.twosome.enums.Size;
+import sopt.twosome.enums.Temperature;
+import sopt.twosome.enums.Togo;
+
+import java.util.List;
+
+public record FavoriteListResponse(
+        List<FavoriteResponse> favoriteList
+) {
+    public record FavoriteResponse(
+            long id,
+            String name,
+            int price,
+            String imageUrl,
+            int temperature,
+            int size,
+            int coffeeBean,
+            int togo,
+            boolean personal
+    ) {
+        public static FavoriteResponse of(final Long id, final String name, final int price, final String imageUrl, final Temperature temperature, final Size size, final CoffeeBean coffeeBean, final Togo togo, final boolean personal) {
+            return new FavoriteResponse(id, name, price, imageUrl, temperature.getIndex(), size.getIndex(), coffeeBean.getIndex(), togo.getIndex(), personal);
+        }
+
+    }
+
+    public static FavoriteListResponse of(final List<FavoriteResponse> favoriteList) {
+        return new FavoriteListResponse(favoriteList);
+    }
+}

--- a/src/main/java/sopt/twosome/repository/FavoriteRepository.java
+++ b/src/main/java/sopt/twosome/repository/FavoriteRepository.java
@@ -27,4 +27,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @Modifying
     @Query("DELETE FROM Favorite f WHERE f.member.id = :memberId AND f.id IN :favoriteIds")
     void deleteByMemberIdAndIds(@Param("memberId") long memberId, @Param("favoriteIds") List<Long> favoriteIds);
+
+    List<Favorite> findAllByMemberId(long memberId);
 }

--- a/src/main/java/sopt/twosome/service/Favorite/FavoriteService.java
+++ b/src/main/java/sopt/twosome/service/Favorite/FavoriteService.java
@@ -7,6 +7,8 @@ import sopt.twosome.domain.Favorite;
 import sopt.twosome.domain.Member;
 import sopt.twosome.domain.Menu;
 import sopt.twosome.dto.request.FavoriteCreateRequest;
+import sopt.twosome.dto.response.FavoriteListResponse;
+import sopt.twosome.repository.FavoriteRepository;
 import sopt.twosome.service.Member.MemberRetriever;
 import sopt.twosome.service.Menu.MenuRetriever;
 import java.util.Arrays;
@@ -21,6 +23,7 @@ public class FavoriteService {
 
     private final FavoriteSaver favoriteSaver;
     private final FavoriteRemover favoriteRemover;
+    private final FavoriteRepository favoriteRepository;
 
     //메뉴 즐겨찾기(저장) 기능
     @Transactional
@@ -62,5 +65,26 @@ public class FavoriteService {
         } else {
             throw new IllegalArgumentException("all 이나 favoriteIds 둘 중 하나는 반드시 포함되어야 합니다.");
         }
+    }
+
+    //즐겨찾기 리스트 조회 기능
+    @Transactional(readOnly = true)
+    public FavoriteListResponse getListFavorites(final long memberId) {
+        List<Favorite> favoriteList = favoriteRepository.findAllByMemberId(memberId);
+        List<FavoriteListResponse.FavoriteResponse> favoriteResponse = favoriteList.stream()
+                .map(favorite -> FavoriteListResponse.FavoriteResponse.of(
+                        favorite.getId(),
+                        favorite.getName(),
+                        favorite.getPrice(),
+                        favorite.getImageUrl(),
+                        favorite.getTemperature(),
+                        favorite.getSize(),
+                        favorite.getCoffeeBean(),
+                        favorite.getTogo(),
+                        favorite.getPersonal()
+                ))
+                .toList();
+
+        return FavoriteListResponse.of(favoriteResponse);
     }
 }

--- a/src/main/java/sopt/twosome/service/Favorite/FavoriteService.java
+++ b/src/main/java/sopt/twosome/service/Favorite/FavoriteService.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FavoriteService {
 
     private final MemberRetriever memberRetriever;
@@ -50,6 +51,8 @@ public class FavoriteService {
                 .imageUrl(menu.getImageUrl())
                 .build();
 
+        //favorite 존재하면 예외 처리
+
         return favoriteSaver.save(favoriteItem);
     }
 
@@ -68,7 +71,6 @@ public class FavoriteService {
     }
 
     //즐겨찾기 리스트 조회 기능
-    @Transactional(readOnly = true)
     public FavoriteListResponse getListFavorites(final long memberId) {
         List<Favorite> favoriteList = favoriteRepository.findAllByMemberId(memberId);
         List<FavoriteListResponse.FavoriteResponse> favoriteResponse = favoriteList.stream()


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #8 
- 메뉴 상세조회 관련 issue와의 브랜치 문제로 feat/10 브랜치를 새로 생성하였습니다.

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
즐겨찾기 목록 조회 api 입니다.

* 실행 결과
* personal=true인 경우, 원래 menu의 price에서 300원 할인된 가격으로 표시됩니다.
![image](https://github.com/user-attachments/assets/38e37715-a379-46fb-b281-13cc64ba26ae)


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
db 확인해야 하므로, 추후 수정 가능성 있습니다.


## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
확인 후 연락 주세요!
